### PR TITLE
chore(types): Allow locales to be readonly

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 
 export interface Config {
-  locales: string[];
+  locales: readonly string[];
   defaultLocale: string;
   localeCookie?: string;
   localeDetector?: ((request: NextRequest, config: Config) => string) | false;


### PR DESCRIPTION
Currently it is not possible to pass a readonly array to the locales field in the config. This PR fixes that such that both mutable and readonly arrays can be used.