### PR TITLE
feat: Add support for setting cookie attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You now have internationalized routing!
 | `noPrefix`        | `false`         | boolean                           |           |
 | `serverSetCookie` | `'always'`      | "always" \| "if-empty" \| "never" |           |
 | `basePath`        | `''`            | string                            |           |
+| `cookieOptions`   | (See below)     | CookieOptions                     |           |
 
 ## Locale Path Prefixing
 
@@ -123,6 +124,27 @@ The `serverSetCookie` option automatically changes a visitor's preferred locale 
 `'never'`: The middleware will not automatically set the cookie.
 
 If you are using `noPrefix`, the `serverSetCookie` option does not do anything since there is no locale in the pathname to read from. All language changing must be done by setting the cookie manually.
+
+## Cookie Options (optional)
+
+You can set the `cookieOptions` option to configure the cookie that is set by the middleware. This option is an object that can contain any of the following properties:
+
+- `domain`: A string representing the domain where the cookie is available.
+- `sameSite`: A string representing the SameSite attribute of the cookie.
+- `maxAge`: A number representing the number of seconds until the cookie expires.
+- `path`: A string representing the path where the cookie is available.
+Here's a table with the cookie options, including default values for `path` and `maxAge`, and a clear explanation for the `path` default:
+
+## Cookie Options (optional)
+
+You can set the `cookieOptions` option to configure the cookie that is set by the middleware. This option is an object that can contain any of the following properties:
+
+| Property   | Default Value                    | Type                                   |
+|------------|----------------------------------|----------------------------------------|
+| `domain`   | -                                | string                                 |
+| `sameSite` | `'strict'`                       | "lax" \| "strict" \| "none" \| boolean |
+| `maxAge`   | `31536000`                       | number                                 |
+| `path`     | The base path of the current URL | string                                 |
 
 ## Using `basePath` (optional)
 

--- a/src/i18nRouter.ts
+++ b/src/i18nRouter.ts
@@ -136,7 +136,8 @@ function i18nRouter(request: NextRequest, config: Config): NextResponse {
       response.cookies.set(localeCookie, pathLocale, {
         path: request.nextUrl.basePath || undefined,
         sameSite: 'strict',
-        maxAge: 31536000 // expires after one year
+        maxAge: 31536000, // expires after one year
+        ...config.cookieOptions
       });
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+interface CookieOptions {
+  domain?: string;
+  path?: string;
+  maxAge?: number;
+  sameSite?: true | false | 'lax' | 'strict' | 'none';
+}
 
 export interface Config {
   locales: readonly string[];
@@ -9,4 +16,5 @@ export interface Config {
   noPrefix?: boolean;
   basePath?: string;
   serverSetCookie?: 'if-empty' | 'always' | 'never';
+  cookieOptions?: CookieOptions;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ interface CookieOptions {
   domain?: string;
   path?: string;
   maxAge?: number;
-  sameSite?: true | false | 'lax' | 'strict' | 'none';
+  sameSite?: boolean | 'lax' | 'strict' | 'none';
 }
 
 export interface Config {


### PR DESCRIPTION
This PR adds the possibility for setting cookie attributes of the locale cookie. With this you can for example set up sharing of cookies between a root and subdomain, such as sharing the locale cookie between `foo.example.com` and `example.com`.

I opted for not supporting all the different possible attributes, such as `expires` since that would "conflict" with the `maxAge` attribute. Let me know if you think I should extend the list of options.

I could have imported the types for the `ResponseCookie` type Next.js uses internally, but since that type is not part of the public exports it felt safer to just manually write the type. Shouldn't require much maintaining since these APIs don't change very often.

I for the life of me couldn't figure out how to test that the cookies get set properly since the `response.cookies` store seems to be empty when testing. So some help there would be gladly appreciated.

