### PR TITLE
Added permanentRedirect option to i18nRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,18 @@ You now have internationalized routing!
 
 ## Config Options
 
-| Option            | Default value   | Type                              | Required? |
-| ----------------- | --------------- | --------------------------------- | --------- |
-| `locales`         |                 | string[]                          | &#10004;  |
-| `defaultLocale`   |                 | string                            | &#10004;  |
-| `prefixDefault`   | `false`         | boolean                           |           |
-| `localeDetector`  | (See below)     | function \| false                 |           |
-| `localeCookie`    | `'NEXT_LOCALE'` | string                            |           |
-| `noPrefix`        | `false`         | boolean                           |           |
-| `serverSetCookie` | `'always'`      | "always" \| "if-empty" \| "never" |           |
-| `cookieOptions`   | (See below)     | object                            |           |
-| `basePath`        | `''`            | string                            |           |
+| Option              | Default value   | Type                              | Required? |
+| ------------------- | --------------- | --------------------------------- | --------- |
+| `locales`           |                 | string[]                          | &#10004;  |
+| `defaultLocale`     |                 | string                            | &#10004;  |
+| `prefixDefault`     | `false`         | boolean                           |           |
+| `permanentRedirect` | `false`         | boolean                           |           |
+| `localeDetector`    | (See below)     | function \| false                 |           |
+| `localeCookie`      | `'NEXT_LOCALE'` | string                            |           |
+| `noPrefix`          | `false`         | boolean                           |           |
+| `serverSetCookie`   | `'always'`      | "always" \| "if-empty" \| "never" |           |
+| `cookieOptions`     | (See below)     | object                            |           |
+| `basePath`          | `''`            | string                            |           |
 
 ## Locale Path Prefixing
 
@@ -79,6 +80,7 @@ By default, the `defaultLocale`'s path is not prefixed with the locale. For exam
 **German**: `/de/products`
 
 To also include your default locale in the path, set the `prefixDefault` config option to `true`.
+use permanentRedirect true to redriect using 301(permanent) status instead of 307 (temporary)
 
 To hide all locales from the path, set the `noPrefix` config option to `true`.
 

--- a/__tests__/i18nRouter.test.ts
+++ b/__tests__/i18nRouter.test.ts
@@ -105,6 +105,27 @@ basePaths.forEach(basePath => {
       );
     });
 
+    it('should redirect permanently when prefixDefault is true and permanentRedirect is true', () => {
+      const mockRedirect = jest.fn();
+      NextResponse.redirect = mockRedirect;
+
+      const request = mockRequest('/faq', ['en']);
+
+      i18nRouter(request, {
+        locales: ['en', 'jp'],
+        defaultLocale: 'en',
+        prefixDefault: true,
+        permanentRedirect: true,
+        basePath,
+        serverSetCookie: 'never'
+      });
+
+      expect(mockRedirect).toHaveBeenCalledWith(
+        new URL(`${basePath}/en/faq`, 'https://example.com'),
+        301
+      );
+    });
+
     it('should redirect when prefixDefault is false and defaultLocale does not match accept-language', () => {
       const mockRedirect = jest.fn();
       NextResponse.redirect = mockRedirect;

--- a/src/i18nRouter.ts
+++ b/src/i18nRouter.ts
@@ -18,6 +18,7 @@ function i18nRouter(request: NextRequest, config: Config): NextResponse {
     localeCookie = 'NEXT_LOCALE',
     localeDetector = defaultLocaleDetector,
     prefixDefault = false,
+    permanentRedirect = false,
     basePath = '',
     serverSetCookie = 'always',
     noPrefix = false,
@@ -92,6 +93,9 @@ function i18nRouter(request: NextRequest, config: Config): NextResponse {
         responseOptions
       );
     } else if (prefixDefault || locale !== defaultLocale) {
+      if (permanentRedirect) {
+        return NextResponse.redirect(new URL(newPath, request.url), 301);
+      }
       return NextResponse.redirect(new URL(newPath, request.url));
     } else {
       // prefixDefault is false and using default locale
@@ -116,7 +120,12 @@ function i18nRouter(request: NextRequest, config: Config): NextResponse {
 
         newPath = `${basePath}${newPath}`;
 
-        response = NextResponse.redirect(new URL(newPath, request.url));
+        if (permanentRedirect) {
+          response = NextResponse.redirect(new URL(newPath, request.url), 301);
+        }
+        {
+          response = NextResponse.redirect(new URL(newPath, request.url));
+        }
       }
     }
 
@@ -132,9 +141,17 @@ function i18nRouter(request: NextRequest, config: Config): NextResponse {
         pathWithoutLocale += request.nextUrl.search;
       }
 
-      response = NextResponse.redirect(
-        new URL(`${basePath}${pathWithoutLocale}`, request.url)
-      );
+      if (permanentRedirect) {
+        response = NextResponse.redirect(
+          new URL(`${basePath}${pathWithoutLocale}`, request.url),
+          301
+        );
+      }
+      {
+        response = NextResponse.redirect(
+          new URL(`${basePath}${pathWithoutLocale}`, request.url)
+        );
+      }
     }
 
     const setCookie = () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface Config {
   localeCookie?: string;
   localeDetector?: ((request: NextRequest, config: Config) => string) | false;
   prefixDefault?: boolean;
+  permanentRedirect?: boolean;
   noPrefix?: boolean;
   basePath?: string;
   serverSetCookie?: 'if-empty' | 'always' | 'never';


### PR DESCRIPTION
There are situations when you could prefer to have permanent redirects with 301 status instead of temp redirects with 307/308 status. 

I added optional prop for that.