### PR TITLE
Fix bug where usePathname returns null and useCurrentLocale throws

### DIFF
--- a/__tests__/useCurrentLocale.test.ts
+++ b/__tests__/useCurrentLocale.test.ts
@@ -1,6 +1,6 @@
 import { useCurrentLocale } from '../src/client';
 
-let pathname: string;
+let pathname: string | null;
 
 jest.mock('next/navigation', () => ({
   usePathname() {
@@ -99,6 +99,18 @@ basePaths.forEach(basePath => {
       };
 
       expect(useCurrentLocale(config, 'random_cookie=sdf')).toEqual('en');
+    });
+
+    it('should return defaultLocale when pathname is null', () => {
+      pathname = null;
+
+      const config = {
+        defaultLocale: 'en',
+        locales: ['en', 'de'],
+        basePath
+      };
+
+      expect(useCurrentLocale(config)).toEqual('en');
     });
   });
 });

--- a/src/client/useCurrentLocale.ts
+++ b/src/client/useCurrentLocale.ts
@@ -54,7 +54,9 @@ const useCurrentLocale = (
 
     return (
       currentPathname === `${base}/${locale}` ||
-      currentPathname.startsWith(`${base}/${locale}/`)
+      // While the return type of usePathname is string, there are times when usePathname returns null, so we need to null check:
+      // https://nextjs.org/docs/app/api-reference/functions/use-pathname
+      currentPathname?.startsWith(`${base}/${locale}/`)
     );
   });
 


### PR DESCRIPTION
According to the Good to know section in the Next.js docs there are times when usePathname returns null:
https://nextjs.org/docs/app/api-reference/functions/use-pathname

While it's not written in the docs, usePathname also seems to return null when used in global-error.tsx. I noticed this when using useCurrentLocale inside of global-error.tsx, causing useCurrentLocale to throw, and the global error page not showing.

I've added a null check, causing useCurrentLocale to return the default locale when usePathname returns null. I've also added a test.

Please let me know if there is anything else I should do.