### PR TITLE
Remove responseOptions

### DIFF
--- a/src/i18nRouter.ts
+++ b/src/i18nRouter.ts
@@ -33,13 +33,7 @@ function i18nRouter(request: NextRequest, config: Config): NextResponse {
   const pathname = request.nextUrl.pathname;
   const basePathTrailingSlash = basePath.endsWith('/');
 
-  const responseOptions = {
-    request: {
-      headers: new Headers(request.headers)
-    }
-  };
-
-  let response = NextResponse.next(responseOptions);
+  let response = NextResponse.next();
 
   let cookieLocale;
   // check cookie for locale
@@ -93,16 +87,14 @@ function i18nRouter(request: NextRequest, config: Config): NextResponse {
 
     if (noPrefix) {
       response = NextResponse.rewrite(
-        new URL(newPath, request.url),
-        responseOptions
+        new URL(newPath, request.url)
       );
     } else if (prefixDefault || locale !== defaultLocale) {
       return NextResponse.redirect(new URL(newPath, request.url));
     } else {
       // prefixDefault is false and using default locale
       response = NextResponse.rewrite(
-        new URL(newPath, request.url),
-        responseOptions
+        new URL(newPath, request.url)
       );
     }
   } else {


### PR DESCRIPTION
This is redundant because you set .rewrite, .redirect request headers that overwrite the current headers.

“If this is set, the request headers will be overridden with this value.”

I checked through Charles just in case, the headers agree before and after my changes.