### PR TITLE
fix: canonicalize cookie redirects for default locale

### DIFF
--- a/__tests__/i18nRouter.test.ts
+++ b/__tests__/i18nRouter.test.ts
@@ -297,6 +297,42 @@ basePaths.forEach(basePath => {
       );
     });
 
+    it('should redirect to cookie locale when default locale is in path and serverSetCookie is if-empty', () => {
+      const mockRedirect = jest.fn().mockReturnValue(new NextResponse());
+      NextResponse.redirect = mockRedirect;
+
+      const request = mockRequest('/en/faq', ['en'], 'jp');
+
+      i18nRouter(request, {
+        locales: ['en', 'de', 'jp'],
+        defaultLocale: 'en',
+        basePath,
+        serverSetCookie: 'if-empty'
+      });
+
+      expect(mockRedirect.mock.calls[0][0].href).toEqual(
+        new URL(`${basePath}/jp/faq`, 'https://example.com').href
+      );
+    });
+
+    it('should remove default locale prefix when redirecting to cookie locale', () => {
+      const mockRedirect = jest.fn().mockReturnValue(new NextResponse());
+      NextResponse.redirect = mockRedirect;
+
+      const request = mockRequest('/de/faq', ['en'], 'en');
+
+      i18nRouter(request, {
+        locales: ['en', 'de', 'jp'],
+        defaultLocale: 'en',
+        basePath,
+        serverSetCookie: 'if-empty'
+      });
+
+      expect(mockRedirect.mock.calls[0][0].href).toEqual(
+        new URL(`${basePath}/faq`, 'https://example.com').href
+      );
+    });
+
     it('should not redirect when serverSetCookie is always', () => {
       const mockRedirect = jest.fn().mockReturnValue(new NextResponse());
       NextResponse.redirect = mockRedirect;

--- a/src/i18nRouter.ts
+++ b/src/i18nRouter.ts
@@ -109,39 +109,42 @@ function i18nRouter(request: NextRequest, config: Config): NextResponse {
       );
     }
   } else {
+    const pathWithoutLocale = pathname.slice(`/${pathLocale}`.length) || '/';
+    const getPathForLocale = (locale: string) => {
+      let newPath = pathWithoutLocale;
+
+      if (prefixDefault || locale !== defaultLocale) {
+        newPath = `/${locale}${pathWithoutLocale === '/' ? '' : pathWithoutLocale}`;
+      }
+
+      if (basePathTrailingSlash) {
+        newPath = newPath.slice(1);
+      }
+
+      newPath = `${basePath}${newPath}`;
+
+      if (request.nextUrl.search) {
+        newPath += request.nextUrl.search;
+      }
+
+      return newPath;
+    };
+
     if (cookieLocale && cookieLocale !== pathLocale) {
       // if always, do not redirect to cookieLocale
       if (serverSetCookie !== 'always') {
-        let newPath = pathname.replace(`/${pathLocale}`, `/${cookieLocale}`);
-
-        if (request.nextUrl.search) {
-          newPath += request.nextUrl.search;
-        }
-
-        if (basePathTrailingSlash) {
-          newPath = newPath.slice(1);
-        }
-
-        newPath = `${basePath}${newPath}`;
-
-        response = NextResponse.redirect(new URL(newPath, request.url));
+        response = NextResponse.redirect(
+          new URL(getPathForLocale(cookieLocale), request.url)
+        );
+        response.headers.set('x-next-i18n-router-locale', cookieLocale);
+        return response;
       }
     }
 
     // If /default, redirect to /
     if (!prefixDefault && pathLocale === defaultLocale) {
-      let pathWithoutLocale = pathname.slice(`/${pathLocale}`.length) || '/';
-
-      if (basePathTrailingSlash) {
-        pathWithoutLocale = pathWithoutLocale.slice(1);
-      }
-
-      if (request.nextUrl.search) {
-        pathWithoutLocale += request.nextUrl.search;
-      }
-
       response = NextResponse.redirect(
-        new URL(`${basePath}${pathWithoutLocale}`, request.url)
+        new URL(getPathForLocale(defaultLocale), request.url)
       );
     }
 


### PR DESCRIPTION
This fixes cookie-driven redirects when the target locale is the default locale and `prefixDefault` is disabled.

The current path-locale branch builds the cookie redirect with a raw `pathname.replace(...)`. That breaks canonical default-locale handling in both directions:
- `/en/...` + cookie `jp` can be flattened back to `/...`
- `/de/...` + cookie `en` can redirect to `/en/...` instead of the canonical unprefixed path

This patch builds the redirect target from the locale-stripped pathname and applies the same default-locale canonicalization rules used elsewhere in the router. It also adds regression coverage for both edge cases.

Behavior stays unchanged for non-default locale redirects.